### PR TITLE
fix xdebug toggle command to be able to work from any level

### DIFF
--- a/.docksal/commands/php/xdebug
+++ b/.docksal/commands/php/xdebug
@@ -5,4 +5,4 @@
 #: exec_target = cli
 
 set -e
-./.docksal/commands/php/ext xdebug $1
+${PROJECT_ROOT}/.docksal/commands/php/ext xdebug $1


### PR DESCRIPTION
This is a small change that allows users to toggle xdebug from any directory in the project. This is helpful since most work would happen in either docroot, or a module, neither of allow for xdebug toggling at the moment