### PR TITLE
Fix browser output URLs generated during testing.

### DIFF
--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -13,8 +13,6 @@ DOCKSAL_STACK=default
 #WEB_IMAGE='docksal/web:x.x-apache2.4'
 #DB_IMAGE='docksal/db:x.x-mysql-5.6'
 # Use a newer cli image
-# TODO: this override can be removed once Docksal 1.13.0 is released.
-CLI_IMAGE='docksal/cli:2.8-php7.3'
 
 # Override virtual host (matches project folder name by default)
 #VIRTUAL_HOST=drupal8.docksal

--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -10,3 +10,9 @@ services:
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}
+
+  cli:
+    environment:
+      # Allows browser output URLs generated during tests to be viewable in the
+      # local browser.
+      - BROWSERTEST_OUTPUT_BASE_URL=http://${VIRTUAL_HOST}

--- a/.docksal/settings/phpunit.xml
+++ b/.docksal/settings/phpunit.xml
@@ -27,7 +27,7 @@
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://user:user@db/default"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp"/>
     <!-- Selenium configuration for JS tests. -->
     <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browser": "chrome", "chrome": {"switches":["--disable-gpu", "--headless"]}}, "http://browser:4444/wd/hub"]'/>
     <!-- To disable deprecation testing completely uncomment the next line. -->


### PR DESCRIPTION
- Also removes hard-coded docksal version.

Note that `BROWSERTEST_OUTPUT_DIRECTORY` just needs to be set to a non-empty value. The actual output is saved to a simpletest directory, and the urls looks something like this at the bottom of tests:

```
http://drupal8-contrib.docksal/sites/simpletest/browser_output/Drupal_Tests_content_moderation_notifications_Functional_Form_CrudFormTest-78-93885931.html
```